### PR TITLE
fix: 兼容特殊文件名，优化强度染色模式

### DIFF
--- a/public/js/editor.js
+++ b/public/js/editor.js
@@ -957,7 +957,7 @@ function Editor(editorUi, wrapperUi, editorCfg, data, name="editor"){
         }
 
         var frame_selector_str = meta.frames.map(function(f){
-            return "<option value="+f+">"+f + "</option>";
+            return `<option value="${f}">${f}</option>`;
         }).reduce(function(x,y){return x+y;}, "<option>--frame--</option>");
 
         this.editorUi.querySelector("#frame-selector").innerHTML = frame_selector_str;
@@ -2603,8 +2603,8 @@ function Editor(editorUi, wrapperUi, editorCfg, data, name="editor"){
 
         // obj type selector
         var options = "";
-        for (var o in obj_type_map){
-            options += '<option value="'+o+'" class="' +o+ '">'+o+ '</option>';        
+        for (var o in obj_type_map){   
+            options += `<option value="${o}" class="${o}">${o}</option>`
         }
 
         this.editorUi.querySelector("#floating-things #object-category-selector").innerHTML = options;

--- a/public/js/header.js
+++ b/public/js/header.js
@@ -43,9 +43,9 @@ var Header=function(ui, data, cfg, onSceneChanged, onFrameChanged, onObjectSelec
         for (let scene in sceneDescList)
         {
             if (data.sceneDescList[scene])
-                scene_selector_str += "<option value="+scene +">"+scene + " - " +data.sceneDescList[scene].scene + "</option>";
+                scene_selector_str += `<option value="${scene}">${scene} - ${data.sceneDescList[scene].scene}</option>`;
             else
-                scene_selector_str += "<option value="+scene +">"+scene+ "</option>";
+                scene_selector_str += `<option value="${scene}">${scene}</option>`;
         }
 
         this.ui.querySelector("#scene-selector").innerHTML = scene_selector_str;

--- a/public/js/obj_id_list.js
+++ b/public/js/obj_id_list.js
@@ -31,19 +31,15 @@ class ObjectIdManager
     setObjdIdListOptions()
     {
         let objSelOptions = this.objectList.map(function(c){
-            return "<option value="+c.id+">"+String(c.id) +"-"+ c.category+"</option>";
+            return `<option value="${c.id}">${c.id}-${c.category}</option>`;
           }).reduce(function(x,y){return x+y;},
                     "<option>--object--</option>");
         document.getElementById("object-selector").innerHTML = objSelOptions;
 
 
         let objIdsOptions = this.objectList.map(function(c){
-            return "<option value="+c.id+">"+c.category+"</option>";
-        }).reduce(function(x,y){return x+y;}, 
-                        //"<option value='auto'></option><option value='new'></option>");
-                        //"<option value='new'>suggest a new id</option>"
-                        ""
-                        );
+            return `<option value="${c.id}">${c.id}-${c.category}</option>`;
+        }).reduce(function(x,y){return x+y;}, "");
 
         document.getElementById("obj-ids-of-scene").innerHTML = objIdsOptions;
     }


### PR DESCRIPTION
option标签的value原先没有使用引号包裹，如果文件名中有空格会出错。
原强度染色所乘的系数应除以255，现利用point_brightness项的值来放大强度以实现可调的颜色对比度。
![效果图](https://github.com/naurril/SUSTechPOINTS/assets/47098840/e7dba8a2-2ea8-440c-9a7f-d64322f43324)
